### PR TITLE
Add paragonie/random_compat package for supporting random_bytes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
   },
   "require": {
     "php": ">=5.6.4",
+    "paragonie/random_compat": ">=1",
     "ext-openssl": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Could you please check if this works on your machine.
You could test it with prospectus, but it already had `paragonie/random_compat` as one of dependencies.
In theory if `composer install` works without issue this should work fine.